### PR TITLE
Fix GitHub Actions and Holepunch imports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: macos-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -55,25 +55,25 @@ jobs:
         xcrun simctl shutdown booted
     
     - name: Upload Chrome extension artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: chrome-extension
         path: artifacts/chrome-extension.zip
     
     - name: Upload Safari iOS artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: safari-ios-app
         path: artifacts/safari-ios-app
     
     - name: Upload test screenshots
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-screenshots
         path: artifacts/screenshots
     
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: test-results

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,52 @@
+# Create a Cross-Platform Browser History Tracker Extension
+
+## Core Requirements
+Create a browser extension that tracks browsing history with the following features:
+- Track device_id, webpage URL, and title for each history entry
+- Use Holepunch (Hypercore, Hyperbee, Hyperswarm) for peer-to-peer synchronization across devices
+- Allow users to configure public/private keys in the extension settings
+- Implement configurable history expiration (default: 30 days)
+- Support both Chrome and Safari iOS platforms
+
+## Technical Implementation
+1. **Chrome Extension Structure**
+   - Create manifest.json (v3)
+   - Implement background service worker for history tracking
+   - Design popup UI to display recent history
+   - Create options page for configuration
+
+2. **Safari iOS Extension**
+   - Implement Safari web extension compatibility
+   - Create necessary iOS app wrapper
+
+3. **Synchronization**
+   - Implement Holepunch for P2P data synchronization
+   - Store history in Hyperbee database
+   - Use Hyperswarm for peer discovery
+
+4. **User Interface**
+   - Clean, modern UI for viewing history
+   - Settings page for key management and expiration configuration
+   - Display device ID and synchronization status
+
+## CI/CD Pipeline
+Create a GitHub Actions workflow that:
+- Uses macOS runner for building artifacts
+- Generates Chrome extension as a zip file
+- Creates Safari iOS artifact using xcrun (self-signed for simulator use)
+- Implements Playwright tests with xvfb for headless testing
+- Takes screenshots during testing for verification
+- Tests iOS functionality in simulator
+- Uploads all artifacts (Chrome extension, Safari iOS app, test results, screenshots)
+
+## Project Structure
+- Organize code with modern JavaScript practices
+- Use webpack for bundling
+- Include comprehensive README
+- Add proper .gitignore
+- Create placeholder icons
+
+## Testing
+- Implement Playwright tests for Chrome extension
+- Create tests that verify multiple extensions working simultaneously
+- Add iOS simulator testing script

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,8 +1,18 @@
 // Import Holepunch for synchronization
-import * as Hyperswarm from '@hyperswarm/dht';
-import Hyperbee from 'hyperbee';
-import Hypercore from 'hypercore';
-import b4a from 'b4a';
+// Using dynamic imports to ensure compatibility with browser extensions
+const importHolepunch = async () => {
+  try {
+    const Hyperswarm = await import('@hyperswarm/dht');
+    const Hyperbee = await import('hyperbee');
+    const Hypercore = await import('hypercore');
+    const b4a = await import('b4a');
+    
+    return { Hyperswarm, Hyperbee, Hypercore, b4a };
+  } catch (error) {
+    console.error('Failed to import Holepunch modules:', error);
+    return null;
+  }
+};
 
 // Global variables
 let deviceId = '';
@@ -49,33 +59,47 @@ function generateDeviceId() {
 
 // Generate new public/private key pair
 async function generateNewKeys() {
-  const core = new Hypercore(null);
-  await core.ready();
-  
-  publicKey = b4a.toString(core.key, 'hex');
-  privateKey = b4a.toString(core.secretKey, 'hex');
-  
-  await chrome.storage.local.set({ publicKey, privateKey });
+  try {
+    const modules = await importHolepunch();
+    if (!modules) return;
+    
+    const { Hypercore, b4a } = modules;
+    
+    const core = new Hypercore.default(null);
+    await core.ready();
+    
+    publicKey = b4a.default.toString(core.key, 'hex');
+    privateKey = b4a.default.toString(core.secretKey, 'hex');
+    
+    await chrome.storage.local.set({ publicKey, privateKey });
+  } catch (error) {
+    console.error('Failed to generate new keys:', error);
+  }
 }
 
 // Initialize Holepunch for synchronization
 async function initializeHolepunch() {
   try {
+    const modules = await importHolepunch();
+    if (!modules) return;
+    
+    const { Hypercore, Hyperbee, Hyperswarm, b4a } = modules;
+    
     // Create a hypercore with the provided keys
-    historyCore = new Hypercore('./history-storage', b4a.from(publicKey, 'hex'), {
-      secretKey: b4a.from(privateKey, 'hex')
+    historyCore = new Hypercore.default('./history-storage', b4a.default.from(publicKey, 'hex'), {
+      secretKey: b4a.default.from(privateKey, 'hex')
     });
     
     await historyCore.ready();
     
     // Create a hyperbee database on top of the hypercore
-    historyBee = new Hyperbee(historyCore, {
+    historyBee = new Hyperbee.default(historyCore, {
       keyEncoding: 'utf-8',
       valueEncoding: 'json'
     });
     
     // Join the swarm to sync with other devices
-    swarm = new Hyperswarm();
+    swarm = new Hyperswarm.default();
     
     swarm.on('connection', (conn) => {
       // Replicate the hypercore with peers

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,6 +1,16 @@
 // Import Hypercore for key generation
-import Hypercore from 'hypercore';
-import b4a from 'b4a';
+// Using dynamic imports to ensure compatibility with browser extensions
+const importHolepunch = async () => {
+  try {
+    const Hypercore = await import('hypercore');
+    const b4a = await import('b4a');
+    
+    return { Hypercore, b4a };
+  } catch (error) {
+    console.error('Failed to import Holepunch modules:', error);
+    return null;
+  }
+};
 
 // DOM elements
 const deviceIdInput = document.getElementById('device-id');
@@ -49,11 +59,19 @@ function generateDeviceId() {
 // Generate new public/private key pair
 async function generateNewKeys() {
   try {
-    const core = new Hypercore(null);
+    const modules = await importHolepunch();
+    if (!modules) {
+      showStatusMessage('Failed to load Holepunch modules', 'error');
+      return;
+    }
+    
+    const { Hypercore, b4a } = modules;
+    
+    const core = new Hypercore.default(null);
     await core.ready();
     
-    const publicKey = b4a.toString(core.key, 'hex');
-    const privateKey = b4a.toString(core.secretKey, 'hex');
+    const publicKey = b4a.default.toString(core.key, 'hex');
+    const privateKey = b4a.default.toString(core.secretKey, 'hex');
     
     publicKeyInput.value = publicKey;
     privateKeyInput.value = privateKey;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,8 +1,18 @@
 // Import Holepunch for reading history
-import * as Hyperswarm from '@hyperswarm/dht';
-import Hyperbee from 'hyperbee';
-import Hypercore from 'hypercore';
-import b4a from 'b4a';
+// Using dynamic imports to ensure compatibility with browser extensions
+const importHolepunch = async () => {
+  try {
+    const Hyperswarm = await import('@hyperswarm/dht');
+    const Hyperbee = await import('hyperbee');
+    const Hypercore = await import('hypercore');
+    const b4a = await import('b4a');
+    
+    return { Hyperswarm, Hyperbee, Hypercore, b4a };
+  } catch (error) {
+    console.error('Failed to import Holepunch modules:', error);
+    return null;
+  }
+};
 
 // DOM elements
 const deviceIdElement = document.getElementById('device-id');
@@ -44,21 +54,29 @@ async function initialize() {
 // Initialize Holepunch for reading history
 async function initializeHolepunch(publicKey, privateKey) {
   try {
+    const modules = await importHolepunch();
+    if (!modules) {
+      historyEntriesElement.innerHTML = '<div class="loading">Failed to load Holepunch modules</div>';
+      return;
+    }
+    
+    const { Hypercore, Hyperbee, Hyperswarm, b4a } = modules;
+    
     // Create a hypercore with the provided keys
-    historyCore = new Hypercore('./history-storage', b4a.from(publicKey, 'hex'), {
-      secretKey: b4a.from(privateKey, 'hex')
+    historyCore = new Hypercore.default('./history-storage', b4a.default.from(publicKey, 'hex'), {
+      secretKey: b4a.default.from(privateKey, 'hex')
     });
     
     await historyCore.ready();
     
     // Create a hyperbee database on top of the hypercore
-    historyBee = new Hyperbee(historyCore, {
+    historyBee = new Hyperbee.default(historyCore, {
       keyEncoding: 'utf-8',
       valueEncoding: 'json'
     });
     
     // Join the swarm to sync with other devices
-    swarm = new Hyperswarm();
+    swarm = new Hyperswarm.default();
     
     swarm.on('connection', (conn) => {
       // Replicate the hypercore with peers

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   mode: 'production',
@@ -38,6 +39,12 @@ module.exports = {
         { from: 'src/images', to: 'images' },
       ],
     }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+    new webpack.DefinePlugin({
+      'process.env.NODE_DEBUG': JSON.stringify(process.env.NODE_DEBUG),
+    }),
   ],
   resolve: {
     extensions: ['.js'],
@@ -49,5 +56,9 @@ module.exports = {
       fs: false,
       os: require.resolve('os-browserify/browser'),
     },
+  },
+  experiments: {
+    topLevelAwait: true,
+    asyncWebAssembly: true,
   },
 };


### PR DESCRIPTION
## Changes

### 1. Update GitHub Actions to use latest versions
- Update actions/upload-artifact from v3 to v4
- Update actions/checkout from v3 to v4
- Update actions/setup-node from v3 to v4

This fixes the error: "This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3"

### 2. Fix Holepunch imports for browser compatibility
- Use dynamic imports for Holepunch modules
- Add proper webpack configuration for dynamic imports
- Add Buffer polyfill and webpack plugins
- Update code to handle ES modules properly

These changes improve browser extension compatibility by using dynamic imports for Holepunch modules and properly configuring webpack to handle ES modules and WebAssembly.